### PR TITLE
feat(skills): discover SKILL.md instead of loose markdown commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Changed
 
+- Skill discovery now reads modern Claude Code `SKILL.md` files instead of loose markdown slash commands. A skill is a directory containing `SKILL.md` whose first block is YAML frontmatter declaring at least `name` (and optionally `description`); unknown frontmatter keys (e.g. `model`, `effort`, `context`) are tolerated so benchmark-style skills load cleanly. The default search order is `./.claude/skills/` → `~/.claude/skills/` → every installed plugin under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/`, with name-collision dedup so earlier dirs win. Plugin attribution is recovered from the cache path. Adds a `pyyaml` runtime dependency (and `types-PyYAML` for dev). Existing `.claude/commands/*.md` slash commands are no longer picked up — migrate them to `.claude/skills/<name>/SKILL.md` with frontmatter.
 - Document mid-stream staleness of `get_session_transcript` in `docs/DESIGN.md`; cross-link `get_session_transcript` and `tail_session_log` MCP tool descriptions so LLM callers pick the right one (#9).
 - `run_skill_by_name` now resolves the skill via `next(...)` instead of building an intermediate list, a small readability cleanup with no behavior change.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic>=2.0",
     "httpx>=0.27",
     "srclight>=0.1",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -21,6 +22,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "ruff>=0.8",
     "mypy>=1.13",
+    "types-PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/src/pydantic_ai_subagent_mcp/skills.py
+++ b/src/pydantic_ai_subagent_mcp/skills.py
@@ -1,12 +1,20 @@
-"""Discover Claude Code skills from the current directory."""
+"""Discover Claude Code skills from the standard locations.
+
+A "skill" is a directory containing a ``SKILL.md`` file whose first
+block is YAML frontmatter declaring at least ``name`` and
+``description``. This is the modern Claude Code skill format used by
+both user skills (``~/.claude/skills/``) and plugins
+(``~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/``).
+"""
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 
 @dataclass
@@ -28,120 +36,116 @@ class Skill:
 
 
 def discover_skills(search_dirs: list[Path] | None = None) -> list[Skill]:
-    """Find all skills available to Claude Code.
+    """Find every ``SKILL.md`` reachable from ``search_dirs``.
 
-    Searches:
-    1. .claude/commands/ in the current directory (project commands)
-    2. ~/.claude/commands/ (user commands)
-    3. Plugin skill directories from .claude/settings.json
+    Skills are de-duplicated by ``name`` in the order the search
+    directories are visited, so earlier directories take precedence.
+    With the default search dirs that means project skills shadow user
+    skills, which in turn shadow plugin-cache skills.
     """
-    skills: list[Skill] = []
-
     if search_dirs is None:
         search_dirs = _default_search_dirs()
+
+    skills: list[Skill] = []
+    seen: set[str] = set()
 
     for search_dir in search_dirs:
         if not search_dir.exists():
             continue
-        # Markdown-based skills (Claude Code slash commands)
-        for md_file in search_dir.rglob("*.md"):
-            skill = _parse_markdown_skill(md_file, search_dir)
-            if skill:
-                skills.append(skill)
+        for skill_md in search_dir.rglob("SKILL.md"):
+            skill = _parse_skill_md(skill_md)
+            if skill is None:
+                continue
+            if skill.name in seen:
+                continue
+            seen.add(skill.name)
+            skills.append(skill)
 
     return skills
 
 
 def _default_search_dirs() -> list[Path]:
-    """Build the default list of directories to search for skills."""
+    """Build the default list of directories to search for ``SKILL.md`` files.
+
+    Order matters: earlier dirs win on name collisions.
+
+    1. ``./.claude/skills/`` (project)
+    2. ``~/.claude/skills/`` (user)
+    3. ``~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/`` (every installed plugin)
+    """
     dirs: list[Path] = []
 
-    # Project-level commands
-    project_cmds = Path(".claude/commands")
-    if project_cmds.exists():
-        dirs.append(project_cmds)
+    project_skills = Path(".claude/skills")
+    if project_skills.exists():
+        dirs.append(project_skills)
 
-    # User-level commands
-    user_cmds = Path.home() / ".claude" / "commands"
-    if user_cmds.exists():
-        dirs.append(user_cmds)
+    user_skills = Path.home() / ".claude" / "skills"
+    if user_skills.exists():
+        dirs.append(user_skills)
 
-    # Plugin skills from settings
-    plugin_dirs = _discover_plugin_skill_dirs()
-    dirs.extend(plugin_dirs)
-
-    return dirs
-
-
-def _discover_plugin_skill_dirs() -> list[Path]:
-    """Find skill directories from installed Claude Code plugins."""
-    dirs: list[Path] = []
-    settings_path = Path(".claude/settings.json")
-    if not settings_path.exists():
-        return dirs
-
-    try:
-        settings = json.loads(settings_path.read_text())
-        # Look for plugin references in permissions or other config
-        plugin_dirs_config = settings.get("pluginDirs", [])
-        for pd in plugin_dirs_config:
-            plugin_path = Path(pd)
-            skills_dir = plugin_path / "skills"
-            if skills_dir.exists():
+    plugins_cache = Path.home() / ".claude" / "plugins" / "cache"
+    if plugins_cache.exists():
+        # marketplace / plugin / version / skills
+        for skills_dir in sorted(plugins_cache.glob("*/*/*/skills")):
+            if skills_dir.is_dir():
                 dirs.append(skills_dir)
-    except (json.JSONDecodeError, KeyError):
-        pass
 
     return dirs
 
 
-def _parse_markdown_skill(md_path: Path, base_dir: Path) -> Skill | None:
-    """Parse a markdown file as a skill definition."""
+_FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+
+
+def _parse_skill_md(skill_md_path: Path) -> Skill | None:
+    """Parse a ``SKILL.md`` into a ``Skill``, returning ``None`` on failure.
+
+    The file must open with a YAML frontmatter block delimited by
+    ``---`` lines, and the frontmatter must define a non-empty ``name``.
+    Unknown frontmatter keys are tolerated. A missing ``description``
+    falls through to the empty string rather than rejecting the skill.
+    """
     try:
-        content = md_path.read_text()
+        content = skill_md_path.read_text()
     except OSError:
         return None
 
-    # Use filename (without extension) as skill name
-    rel_path = md_path.relative_to(base_dir)
-    name = str(rel_path.with_suffix("")).replace("/", ":")
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return None
 
-    # Extract description from first paragraph or heading
-    description = _extract_description(content)
+    try:
+        frontmatter = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(frontmatter, dict):
+        return None
 
-    # Determine plugin name from path
-    plugin_name = _extract_plugin_name(md_path)
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    description = frontmatter.get("description")
+    if not isinstance(description, str):
+        description = ""
 
     return Skill(
-        name=name,
-        description=description,
-        source_path=md_path,
-        plugin_name=plugin_name,
+        name=name.strip(),
+        description=description.strip(),
+        source_path=skill_md_path,
+        plugin_name=_extract_plugin_name(skill_md_path),
     )
 
 
-def _extract_description(content: str) -> str:
-    """Extract a one-line description from markdown content."""
-    lines = content.strip().splitlines()
-    for line in lines:
-        stripped = line.strip()
-        # Skip frontmatter
-        if stripped == "---":
-            continue
-        # Skip headings, grab first real paragraph line
-        if stripped and not stripped.startswith("#"):
-            # Clean up markdown formatting
-            desc = re.sub(r"[*_`]", "", stripped)
-            return desc[:200]
-    return "No description available"
+def _extract_plugin_name(skill_md_path: Path) -> str | None:
+    """Return the owning plugin's name when the skill lives in a plugin cache.
 
-
-def _extract_plugin_name(md_path: Path) -> str | None:
-    """Try to extract plugin name from path."""
-    parts = md_path.parts
-    for i, part in enumerate(parts):
-        if part == "plugins" and i + 1 < len(parts):
-            return parts[i + 1]
-        if part == "skills" and i > 0:
-            return parts[i - 1]
+    Recognises the standard layout
+    ``.../plugins/cache/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``
+    and returns ``<plugin>``. For project or user skills (no plugin
+    cache in the path), returns ``None``.
+    """
+    parts = skill_md_path.parts
+    for i in range(1, len(parts) - 2):
+        if parts[i] == "cache" and parts[i - 1] == "plugins":
+            return parts[i + 2]
     return None

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -5,37 +5,134 @@ from pathlib import Path
 from pydantic_ai_subagent_mcp.skills import discover_skills
 
 
-def test_discover_markdown_skills(tmp_path: Path):
-    commands_dir = tmp_path / "commands"
-    commands_dir.mkdir()
-    (commands_dir / "greet.md").write_text("# Greet\n\nSay hello to the user.\n")
-    (commands_dir / "review.md").write_text("# Review\n\nReview code changes.\n")
+def _write_skill(
+    base: Path,
+    skill_dir: str,
+    name: str,
+    description: str,
+    extra_frontmatter: str = "",
+    body: str = "Body text.",
+) -> Path:
+    """Write a SKILL.md under base/skill_dir/SKILL.md and return its path."""
+    target = base / skill_dir
+    target.mkdir(parents=True, exist_ok=True)
+    extra = f"\n{extra_frontmatter}" if extra_frontmatter else ""
+    skill_md = target / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: {name}\ndescription: {description}{extra}\n---\n\n{body}\n"
+    )
+    return skill_md
 
-    skills = discover_skills([commands_dir])
-    assert len(skills) == 2
-    names = {s.name for s in skills}
-    assert "greet" in names
-    assert "review" in names
+
+def test_discover_skill_md(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "greet", "greet", "Say hello to the user.")
+    _write_skill(skills_dir, "review", "review", "Review code changes.")
+
+    skills = discover_skills([skills_dir])
+
+    assert {s.name for s in skills} == {"greet", "review"}
+    assert {s.description for s in skills} == {
+        "Say hello to the user.",
+        "Review code changes.",
+    }
 
 
-def test_skill_description_extraction(tmp_path: Path):
-    commands_dir = tmp_path / "commands"
-    commands_dir.mkdir()
-    (commands_dir / "deploy.md").write_text(
-        "# Deploy\n\nDeploy the application to production.\n\n## Steps\n..."
+def test_description_comes_from_frontmatter(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "deploy",
+        "deploy",
+        "Deploy the application to production.",
+        body="# Deploy\n\nDetailed body that should be ignored.",
     )
 
-    skills = discover_skills([commands_dir])
+    skills = discover_skills([skills_dir])
+
     assert len(skills) == 1
-    assert "Deploy the application" in skills[0].description
+    assert skills[0].description == "Deploy the application to production."
 
 
-def test_nested_skills(tmp_path: Path):
-    commands_dir = tmp_path / "commands"
-    sub = commands_dir / "ops"
-    sub.mkdir(parents=True)
-    (sub / "restart.md").write_text("Restart the service gracefully.\n")
+def test_extra_frontmatter_keys_tolerated(tmp_path: Path) -> None:
+    """Skills with model/effort/etc. frontmatter (like benchmark skills) load."""
+    skills_dir = tmp_path / "skills"
+    _write_skill(
+        skills_dir,
+        "bench",
+        "bench-sonnet-high",
+        "Benchmark scorer",
+        extra_frontmatter="model: sonnet\neffort: high\ncontext: fork",
+    )
 
-    skills = discover_skills([commands_dir])
+    skills = discover_skills([skills_dir])
+
     assert len(skills) == 1
-    assert skills[0].name == "ops:restart"
+    assert skills[0].name == "bench-sonnet-high"
+
+
+def test_skips_files_without_frontmatter(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    bad = skills_dir / "broken"
+    bad.mkdir(parents=True)
+    (bad / "SKILL.md").write_text("# No frontmatter here\n\nJust prose.\n")
+
+    assert discover_skills([skills_dir]) == []
+
+
+def test_skips_files_with_blank_name(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    bad = skills_dir / "nameless"
+    bad.mkdir(parents=True)
+    (bad / "SKILL.md").write_text("---\nname: \ndescription: foo\n---\n")
+
+    assert discover_skills([skills_dir]) == []
+
+
+def test_dedup_by_name_first_dir_wins(tmp_path: Path) -> None:
+    """When the same skill name appears in two search dirs, the first wins."""
+    project = tmp_path / "project" / "skills"
+    user = tmp_path / "user" / "skills"
+    _write_skill(project, "shared", "shared", "Project version.")
+    _write_skill(user, "shared", "shared", "User version.")
+
+    skills = discover_skills([project, user])
+
+    assert len(skills) == 1
+    assert skills[0].description == "Project version."
+
+
+def test_plugin_name_from_cache_path(tmp_path: Path) -> None:
+    """A SKILL.md inside plugins/cache/<m>/<plugin>/<v>/skills/<s>/ tags the plugin."""
+    plugin_skills = (
+        tmp_path
+        / "plugins"
+        / "cache"
+        / "my-marketplace"
+        / "my-plugin"
+        / "1.0.0"
+        / "skills"
+    )
+    _write_skill(plugin_skills, "frobnicate", "frobnicate", "Frob the nicate.")
+
+    skills = discover_skills([plugin_skills])
+
+    assert len(skills) == 1
+    assert skills[0].plugin_name == "my-plugin"
+
+
+def test_plugin_name_none_for_user_skill(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "solo", "solo", "Standalone skill.")
+
+    skills = discover_skills([skills_dir])
+
+    assert skills[0].plugin_name is None
+
+
+def test_default_search_dirs_handles_missing(monkeypatch, tmp_path: Path) -> None:
+    """Calling discover_skills() with no args is safe even if HOME has nothing."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    # No project/user/plugin dirs exist under tmp_path -- should not raise
+    assert discover_skills() == []

--- a/uv.lock
+++ b/uv.lock
@@ -1715,6 +1715,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
+    { name = "pyyaml" },
     { name = "srclight" },
 ]
 
@@ -1724,6 +1725,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1735,8 +1737,10 @@ requires-dist = [
     { name = "pydantic-ai", specifier = ">=0.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "srclight", specifier = ">=0.1" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev"]
 
@@ -2464,6 +2468,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b3/c2e407ea36e0e4355c135127cee1b88a2cc9a2c92eafca50a360ab9f2708/types_protobuf-7.34.1.20260403.tar.gz", hash = "sha256:8d7881867888e667eb9563c08a916fccdc12bdb5f9f34c31d217cce876e36765", size = 68782, upload-time = "2026-04-03T04:18:09.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/95/24fb0f6fe37b41cf94f9b9912712645e17d8048d4becaf37c1607ddd8e32/types_protobuf-7.34.1.20260403-py3-none-any.whl", hash = "sha256:16d9bbca52ab0f306279958878567df2520f3f5579059419b0ce149a0ad1e332", size = 86011, upload-time = "2026-04-03T04:18:08.245Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Skill discovery rewritten to look for `SKILL.md` files with YAML frontmatter, matching the modern Claude Code skill format used by user skills and plugins. A skill is a directory containing `SKILL.md` whose first block declares at least `name`; unknown frontmatter keys (`model`, `effort`, `context`, …) are tolerated so benchmark-style skills load cleanly.
- Default search order with name-collision dedup (earlier dirs win): `./.claude/skills/` → `~/.claude/skills/` → every installed plugin under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/`. Plugin attribution is recovered from the cache path layout.
- Adds `pyyaml` runtime dep and `types-PyYAML` dev dep. Replaces the previous `.claude/commands/*.md` slash-command parser, so existing project skills must migrate to `.claude/skills/<name>/SKILL.md` with frontmatter.

## Test plan

- [x] `uv run pytest -q` — 169 passed, 2 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — no issues
- [x] New unit tests cover: happy path, frontmatter-only description (body ignored), extra frontmatter keys tolerated, missing frontmatter rejected, blank `name` rejected, dedup across search dirs, plugin attribution from cache path, `None` plugin for user skills, default search dirs safe with empty `$HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)