### PR TITLE
refactor(ollama): introduce ChatClient Protocol for run_agent

### DIFF
--- a/src/pydantic_ai_subagent_mcp/agent.py
+++ b/src/pydantic_ai_subagent_mcp/agent.py
@@ -32,8 +32,8 @@ from .ollama import (
     GEMMA4_TEMPERATURE,
     GEMMA4_TOP_K,
     GEMMA4_TOP_P,
+    ChatClient,
     ContentDeltaCallback,
-    OllamaClient,
 )
 
 logger = logging.getLogger("subagent-mcp.agent")
@@ -143,7 +143,7 @@ async def _dispatch_tool(
 
 async def run_agent(
     *,
-    client: OllamaClient,
+    client: ChatClient,
     model: str,
     system: str,
     user: str | None = None,

--- a/src/pydantic_ai_subagent_mcp/ollama.py
+++ b/src/pydantic_ai_subagent_mcp/ollama.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 import httpx
 
@@ -92,6 +92,28 @@ class TurnResult:
         if self.thinking:
             msg["thinking"] = self.thinking
         return msg
+
+
+@runtime_checkable
+class ChatClient(Protocol):
+    """Structural interface for anything that can drive one chat turn.
+
+    ``run_agent`` depends on this Protocol rather than the concrete
+    ``OllamaClient``, so tests can supply a fake without ``type: ignore``.
+    """
+
+    async def chat_turn(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        num_ctx: int = DEFAULT_NUM_CTX,
+        temperature: float = GEMMA4_TEMPERATURE,
+        top_p: float = GEMMA4_TOP_P,
+        top_k: int = GEMMA4_TOP_K,
+        on_content_delta: ContentDeltaCallback | None = None,
+    ) -> TurnResult: ...
 
 
 class OllamaClient:

--- a/tests/test_agent_parallel_tools.py
+++ b/tests/test_agent_parallel_tools.py
@@ -91,7 +91,7 @@ async def test_single_tool_call_turn_history_shape() -> None:
         _turn(content="done"),
     ])
     result: AgentResult = await run_agent(
-        client=client,  # type: ignore[arg-type]
+        client=client,
         model="test-model",
         system="You are a test agent.",
         user="hello",
@@ -112,7 +112,7 @@ async def test_multi_tool_call_turn_history_shape() -> None:
         _turn(content="done"),
     ])
     result = await run_agent(
-        client=client,  # type: ignore[arg-type]
+        client=client,
         model="test-model",
         system="sys",
         user="go",
@@ -142,7 +142,7 @@ async def test_tool_result_field_name() -> None:
         _turn(content="done"),
     ])
     result = await run_agent(
-        client=client,  # type: ignore[arg-type]
+        client=client,
         model="test-model",
         system="sys",
         user="go",
@@ -160,7 +160,7 @@ async def test_three_parallel_tool_calls() -> None:
         _turn(content="final"),
     ])
     result = await run_agent(
-        client=client,  # type: ignore[arg-type]
+        client=client,
         model="test-model",
         system="sys",
         user="go",
@@ -185,7 +185,7 @@ async def test_multi_tool_call_with_unknown_tool() -> None:
         _turn(content="recovered"),
     ])
     result = await run_agent(
-        client=client,  # type: ignore[arg-type]
+        client=client,
         model="test-model",
         system="sys",
         user="go",


### PR DESCRIPTION
## Summary

- Adds `ChatClient` Protocol to `ollama.py` with the `chat_turn` method signature
- Changes `run_agent` in `agent.py` to accept `ChatClient` instead of concrete `OllamaClient`
- Removes 5 `# type: ignore[arg-type]` suppressions from `test_agent_parallel_tools.py`

No functional changes — `OllamaClient` satisfies the Protocol structurally.

## Test plan

- [x] 160 tests passing
- [x] `mypy --strict` clean (no `type: ignore` needed for test fakes)
- [x] `ruff check` clean

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)