### PR TITLE
fix: wrap store.shutdown() in timeout so SIGTERM is honoured (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Two independent caps protect the server from runaway producers:
 
 Both knobs can be set in `.subagent-mcp.json` or overridden by `SUBAGENT_MCP_MAX_CONCURRENT_RUNS` and `SUBAGENT_MCP_MAILBOX_MAX_DEPTH`. Non-positive or unparseable values silently fall back to the defaults (a misconfigured backpressure knob must never crash the server at boot).
 
+### Shutdown
+
+- **`shutdown_timeout_seconds`** (default `5.0`) — how long the server waits for in-flight session workers to drain during shutdown. If workers do not exit within this window (e.g. a stuck Ollama call), teardown proceeds anyway — closing the Ollama HTTP client and MCP children destroys the transports stuck workers depend on. Set via `.subagent-mcp.json` or `SUBAGENT_MCP_SHUTDOWN_TIMEOUT`.
+
 ### Example: launch a background run, observe it, stop it
 
 ```text

--- a/src/pydantic_ai_subagent_mcp/config.py
+++ b/src/pydantic_ai_subagent_mcp/config.py
@@ -39,6 +39,11 @@ class ServerConfig:
     # bound, and a foreground caller cannot bypass the cap by
     # omitting run_in_background.
     mailbox_max_depth: int = 16
+    # Timeout in seconds for SessionStore.shutdown() during server
+    # teardown. If workers do not drain within this window, teardown
+    # proceeds anyway — closing the Ollama HTTP client and MCP children
+    # destroys the transports stuck workers depend on.
+    shutdown_timeout_seconds: float = 5.0
 
     @classmethod
     def load(cls, config_path: Path | None = None) -> ServerConfig:
@@ -64,6 +69,11 @@ class ServerConfig:
             data.get("mailbox_max_depth", cls.mailbox_max_depth),
             cls.mailbox_max_depth,
         )
+        shutdown_timeout = _positive_float_env(
+            "SUBAGENT_MCP_SHUTDOWN_TIMEOUT",
+            data.get("shutdown_timeout_seconds", cls.shutdown_timeout_seconds),
+            cls.shutdown_timeout_seconds,
+        )
 
         # Environment overrides take precedence
         return cls(
@@ -78,6 +88,7 @@ class ServerConfig:
             inbox_dir=data.get("inbox_dir", cls.inbox_dir),
             max_concurrent_runs=max_concurrent,
             mailbox_max_depth=mailbox_max,
+            shutdown_timeout_seconds=shutdown_timeout,
             mcp_servers_config=data.get(
                 "mcp_servers_config", cls.mcp_servers_config
             ),
@@ -103,6 +114,29 @@ def _positive_int_env(env_var: str, file_value: Any, default: int) -> int:
             pass
     try:
         parsed = int(file_value)
+        if parsed > 0:
+            return parsed
+    except (TypeError, ValueError):
+        pass
+    return default
+
+
+def _positive_float_env(env_var: str, file_value: Any, default: float) -> float:
+    """Resolve a positive-float knob from env / config file / default.
+
+    Same precedence and fallback rules as ``_positive_int_env`` but for
+    float-valued knobs (e.g. timeouts in seconds).
+    """
+    raw = os.environ.get(env_var)
+    if raw is not None:
+        try:
+            parsed = float(raw)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            pass
+    try:
+        parsed = float(file_value)
         if parsed > 0:
             return parsed
     except (TypeError, ValueError):

--- a/src/pydantic_ai_subagent_mcp/config.py
+++ b/src/pydantic_ai_subagent_mcp/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -131,13 +132,13 @@ def _positive_float_env(env_var: str, file_value: Any, default: float) -> float:
     if raw is not None:
         try:
             parsed = float(raw)
-            if parsed > 0:
+            if parsed > 0 and math.isfinite(parsed):
                 return parsed
         except ValueError:
             pass
     try:
         parsed = float(file_value)
-        if parsed > 0:
+        if parsed > 0 and math.isfinite(parsed):
             return parsed
     except (TypeError, ValueError):
         pass

--- a/src/pydantic_ai_subagent_mcp/server.py
+++ b/src/pydantic_ai_subagent_mcp/server.py
@@ -67,8 +67,19 @@ async def _lifespan(_app: FastMCP[None]) -> AsyncIterator[None]:
         yield
     finally:
         store = _get_session_store()
-        with suppress(Exception):
-            await store.shutdown()
+        try:
+            await asyncio.wait_for(
+                store.shutdown(),
+                timeout=config.shutdown_timeout_seconds,
+            )
+        except TimeoutError:
+            logger.warning(
+                "SessionStore.shutdown() timed out after %.1fs; "
+                "proceeding with resource teardown",
+                config.shutdown_timeout_seconds,
+            )
+        except Exception:
+            logger.exception("SessionStore.shutdown() raised unexpectedly")
         if _mcp_loader is not None:
             with suppress(Exception):
                 await _mcp_loader.aclose()

--- a/src/pydantic_ai_subagent_mcp/session.py
+++ b/src/pydantic_ai_subagent_mcp/session.py
@@ -264,15 +264,9 @@ class SessionStore:
         workers = list(self._workers.items())
         for _, w in workers:
             w.cancel()
-        for sid, w in workers:
-            try:
-                await w
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.exception(
-                    "session worker for %s raised during shutdown", sid
-                )
+        if workers:
+            tasks = [w for _, w in workers]
+            await asyncio.gather(*tasks, return_exceptions=True)
         self._workers.clear()
         self._mailboxes.clear()
 

--- a/src/pydantic_ai_subagent_mcp/session.py
+++ b/src/pydantic_ai_subagent_mcp/session.py
@@ -264,11 +264,13 @@ class SessionStore:
         workers = list(self._workers.items())
         for _, w in workers:
             w.cancel()
-        if workers:
-            tasks = [w for _, w in workers]
-            await asyncio.gather(*tasks, return_exceptions=True)
-        self._workers.clear()
-        self._mailboxes.clear()
+        try:
+            if workers:
+                tasks = [w for _, w in workers]
+                await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            self._workers.clear()
+            self._mailboxes.clear()
 
     async def stop_session(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,3 +107,53 @@ def test_backpressure_file_invalid_falls_back_to_default(
     config = ServerConfig.load(config_file)
     assert config.max_concurrent_runs == 4
     assert config.mailbox_max_depth == 16
+
+
+# -- shutdown timeout knob --
+
+
+def test_shutdown_timeout_default() -> None:
+    """The default shutdown timeout is 5.0 seconds."""
+    config = ServerConfig()
+    assert config.shutdown_timeout_seconds == 5.0
+
+
+def test_shutdown_timeout_loaded_from_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SUBAGENT_MCP_SHUTDOWN_TIMEOUT", raising=False)
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"shutdown_timeout_seconds": 10.0}))
+    config = ServerConfig.load(config_file)
+    assert config.shutdown_timeout_seconds == 10.0
+
+
+def test_shutdown_timeout_env_overrides_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"shutdown_timeout_seconds": 10.0}))
+    monkeypatch.setenv("SUBAGENT_MCP_SHUTDOWN_TIMEOUT", "3.0")
+    config = ServerConfig.load(config_file)
+    assert config.shutdown_timeout_seconds == 3.0
+
+
+@pytest.mark.parametrize("bad_value", ["-1", "0", "not-a-number", ""])
+def test_shutdown_timeout_env_invalid_falls_back_to_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    """Garbage env values must not crash the server -- they fall through."""
+    monkeypatch.setenv("SUBAGENT_MCP_SHUTDOWN_TIMEOUT", bad_value)
+    config = ServerConfig.load(tmp_path / "missing.json")
+    assert config.shutdown_timeout_seconds == 5.0
+
+
+def test_shutdown_timeout_file_invalid_falls_back_to_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-positive config-file values fall back to the class default."""
+    monkeypatch.delenv("SUBAGENT_MCP_SHUTDOWN_TIMEOUT", raising=False)
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"shutdown_timeout_seconds": 0}))
+    config = ServerConfig.load(config_file)
+    assert config.shutdown_timeout_seconds == 5.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -138,7 +138,7 @@ def test_shutdown_timeout_env_overrides_file(
     assert config.shutdown_timeout_seconds == 3.0
 
 
-@pytest.mark.parametrize("bad_value", ["-1", "0", "not-a-number", ""])
+@pytest.mark.parametrize("bad_value", ["-1", "0", "inf", "not-a-number", ""])
 def test_shutdown_timeout_env_invalid_falls_back_to_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_value: str
 ) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -509,6 +509,49 @@ async def test_stop_session_on_drop_swallows_exceptions(tmp_path: Path) -> None:
     assert store.has_worker(session.session_id) is False
 
 
+async def test_shutdown_timeout_on_stuck_worker(tmp_path: Path) -> None:
+    """shutdown() wrapped in wait_for raises TimeoutError when a worker
+    is stuck and does not respond to cancellation within the timeout.
+
+    This simulates the scenario from issue #27: a worker is wedged on
+    a hung Ollama call and store.shutdown() would block forever without
+    the timeout wrapper.
+    """
+    store = SessionStore(tmp_path / "sessions")
+    session = store.create("skill", "gemma4:12b")
+    store.get_or_create_mailbox(session.session_id)
+
+    cancel_received = asyncio.Event()
+
+    async def stuck_worker() -> None:
+        """A worker that acknowledges cancellation but refuses to die."""
+        try:
+            await asyncio.Event().wait()  # block forever
+        except asyncio.CancelledError:
+            cancel_received.set()
+            # Simulate a stuck cleanup: re-block instead of exiting.
+            # This is the pathological case — the worker got the cancel
+            # signal but its cleanup path (e.g. awaiting a hung HTTP
+            # response during teardown) never returns.
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(stuck_worker())
+    store.register_worker(session.session_id, task)
+    await asyncio.sleep(0)  # let the worker reach its first await point
+
+    timeout = 0.1  # 100ms — fast for tests
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(store.shutdown(), timeout=timeout)
+
+    # The worker received the cancel signal even though it didn't exit
+    assert cancel_received.is_set()
+
+    # Clean up the stuck task so it doesn't leak into the test runner
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 def test_session_dataclass_defaults() -> None:
     """Session can still be constructed with the minimum required fields."""
     s = Session(


### PR DESCRIPTION
## Summary

- Add `shutdown_timeout_seconds: float = 5.0` to `ServerConfig` with env override `SUBAGENT_MCP_SHUTDOWN_TIMEOUT` and `_positive_float_env` helper (rejects `inf`/`NaN`/non-positive values)
- Wrap `store.shutdown()` in `asyncio.wait_for` in `_lifespan` teardown — on timeout, log a warning and proceed with resource teardown (`mcp_loader.aclose()`, `ollama_client.aclose()`) which destroys transports stuck workers depend on
- Switch `shutdown()` from sequential per-task await to `asyncio.gather(*tasks, return_exceptions=True)` with `try/finally` to ensure registry cleanup even on cancellation

## Test plan

- [x] Config knob tests: default, file load, env override, invalid env (parametrized: -1, 0, inf, not-a-number, ""), invalid file — 10 new tests
- [x] Stuck worker timeout test: worker catches `CancelledError` and re-blocks, `wait_for` raises `TimeoutError` within 100ms
- [x] All 170 tests pass, mypy clean, ruff clean
- [x] Existing shutdown/stop_session tests unaffected

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)