### PR TITLE
docs: rewrite ARCHITECTURE/DESIGN/README for native /api/chat (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-<!-- bump: minor -->
+<!-- bump: patch -->
+
+### Changed
+
+- Documentation rewrite: README, ARCHITECTURE, DESIGN, and CLAUDE.md updated to reflect the post-#25 native /api/chat architecture. ADR-1/2/3 rewritten in place with "Supersedes" notes; ADR-4/5/6/7 preserved verbatim. Component table expanded with `agent.py`, `ollama.py`, `mcp_loader.py`. All stale pydantic-ai references removed (#29).
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # pydantic-ai-subagent-mcp
 
-MCP server that proxies Claude Code skills to local Ollama models via pydantic-ai agents.
+MCP server that proxies Claude Code skills to local Ollama models via a native /api/chat agent loop.
 
 ## Build & Run
 
@@ -14,10 +14,14 @@ uv run mypy src/           # Type check
 
 ## Project structure
 
-- `src/pydantic_ai_subagent_mcp/server.py` -- Main MCP server entry point (FastMCP, tool registration)
+- `src/pydantic_ai_subagent_mcp/server.py` -- Main MCP server entry point (FastMCP, tool registration, orchestration)
+- `src/pydantic_ai_subagent_mcp/agent.py` -- Multi-turn agent loop (`run_agent`), `Tool` dataclass, `AgentResult`
+- `src/pydantic_ai_subagent_mcp/ollama.py` -- Native Ollama /api/chat client, NDJSON streaming, `ChatClient` Protocol
+- `src/pydantic_ai_subagent_mcp/mcp_loader.py` -- External MCP server lifecycle (long-lived child sessions)
 - `src/pydantic_ai_subagent_mcp/config.py` -- Configuration loading from file + env
 - `src/pydantic_ai_subagent_mcp/skills.py` -- Skill discovery from Claude Code command dirs
-- `src/pydantic_ai_subagent_mcp/session.py` -- UUID-keyed session store with transcripts
+- `src/pydantic_ai_subagent_mcp/session.py` -- UUID-keyed session store with Ollama-native messages
+- `src/pydantic_ai_subagent_mcp/inbox.py` -- Durable on-disk outbox for completion notifications
 - `src/pydantic_ai_subagent_mcp/tools.py` -- Built-in tools for subagent runs (files, search, shell)
 - `.mcp.json` -- Claude Code MCP server configuration
 - `.subagent-mcp.json` -- Default server configuration
@@ -34,10 +38,9 @@ uv run mypy src/           # Type check
 
 ## Key dependencies
 
-- `pydantic-ai` -- Agent framework with Ollama support
 - `mcp` -- Model Context Protocol SDK (FastMCP for stdio server)
+- `httpx` -- HTTP client for Ollama /api/chat
 - `srclight` -- Code indexing MCP server (optional, for enhanced code search)
-- `httpx` -- HTTP client for Ollama API
 
 ## CI vs local environment
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pydantic-ai-subagent-mcp
 
-MCP server that proxies Claude Code skills to local Ollama models (gemma4 family) via pydantic-ai agents.
+MCP server that proxies Claude Code skills to local Ollama models (gemma4 family) via a native /api/chat agent loop.
 
 ## What it does
 
@@ -8,7 +8,7 @@ When loaded as an MCP server in Claude Code, it:
 
 1. **Discovers skills** from Claude Code's command directories and installed plugins
 2. **Registers each skill as an MCP tool** with optional model and session parameters
-3. **Delegates execution** to a pydantic-ai agent backed by Ollama, with a rich set of built-in tools (file I/O, code search, shell execution, srclight)
+3. **Delegates execution** to a multi-turn agent loop over Ollama's /api/chat, with a rich set of built-in tools (file I/O, code search, shell execution) and optional external MCP tools (srclight, etc.)
 4. **Manages sessions** with UUID-keyed transcripts so conversations can be resumed
 5. **Supports recursive sub-agents** -- the spawned agent can itself use this MCP to create sub-sub-agents
 6. **Streams output incrementally** — with `streaming: true` (default), each skill run writes text deltas to a `<session_id>.log` file alongside the session JSON. Use the `tail_session_log` tool to poll for live output while a run is in progress.
@@ -47,7 +47,7 @@ Environment variables `OLLAMA_BASE_URL`, `SUBAGENT_MCP_DEFAULT_MODEL`, and `SUBA
 
 ### External MCP servers exposed to subagents
 
-Subagents can call tools from any external MCP server you declare in `.subagent-mcp.servers.json` (the path is configurable via `mcp_servers_config`). The schema follows pydantic-ai's `load_mcp_servers` -- a top-level `mcpServers` object keyed by server name, with `command` / `args` / `env` per stdio server. Env values support `${VAR}` and `${VAR:-default}` expansion. A copy of `.subagent-mcp.servers.json.example` (with `srclight` pre-wired) ships in the repo as a starting point.
+Subagents can call tools from any external MCP server you declare in `.subagent-mcp.servers.json` (the path is configurable via `mcp_servers_config`). The schema is a top-level `mcpServers` object keyed by server name, with `command` / `args` / `env` per stdio server. Env values support `${VAR}` and `${VAR:-default}` expansion. A copy of `.subagent-mcp.servers.json.example` (with `srclight` pre-wired) ships in the repo as a starting point.
 
 ```json
 {
@@ -64,7 +64,7 @@ Subagents can call tools from any external MCP server you declare in `.subagent-
 }
 ```
 
-Each subagent run wraps the agent in `async with agent:`, so server subprocesses are started fresh per turn and torn down on exit. A missing or malformed config file is logged and treated as empty -- the server still boots and subagents simply run with the built-in Python tools only.
+External MCP servers are spawned once at startup by `MCPToolLoader` and held open for the server's entire lifetime via `AsyncExitStack`, so subagent runs do not pay subprocess startup cost per turn. A missing or malformed config file is logged and treated as empty -- the server still boots and subagents simply run with the built-in Python tools only.
 
 ## Background runs and completion notifications
 
@@ -186,7 +186,7 @@ Claude Code
   |                     |-- on tool call:
   |                     |     |-- per-session mailbox + worker actor model
   |                     |     |-- server-wide concurrency semaphore
-  |                     |     |-- creates pydantic-ai Agent with Ollama model
+  |                     |     |-- runs agent loop via OllamaClient.chat_turn
   |                     |     |-- streams response to {session_id}.log
   |                     |     |-- writes completion notification to inbox
   |                     |     \-- returns result (foreground) or "running" (background)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 pydantic-ai-subagent-mcp is an MCP server that bridges Claude Code skills to local
 Ollama models. It sits between Claude Code (MCP client) and Ollama (LLM backend),
-using pydantic-ai as the agent framework.
+using a native multi-turn agent loop over Ollama's /api/chat endpoint.
 
 ## System Context
 
@@ -13,10 +13,15 @@ Claude Code (MCP client)
   |
   +-- stdio --> subagent-mcp (FastMCP server)
   |               |
-  |               +-- pydantic-ai Agent
-  |               |    +-- OpenAIChatModel + OllamaProvider --> Ollama
-  |               |    +-- Built-in tools (file I/O, search, shell)
-  |               |    +-- MCPServerStdio toolsets --> srclight, self (recursive)
+  |               +-- run_agent loop (agent.py)
+  |               |    +-- OllamaClient.chat_turn --> Ollama /api/chat
+  |               |    +-- Tool[] (unified dispatch)
+  |               |         +-- Built-in tools (file I/O, search, shell)
+  |               |         +-- MCP-proxied tools (thin shims via MCPToolLoader)
+  |               |
+  |               +-- MCPToolLoader (mcp_loader.py)
+  |               |    +-- Long-lived MCP child sessions (AsyncExitStack)
+  |               |    \-- srclight, self (recursive), user-declared servers
   |               |
   |               +-- SessionStore (JSON on disk, UUID-keyed)
   |               |    +-- per-session mailbox (asyncio.Queue) + worker task
@@ -31,32 +36,56 @@ Claude Code (MCP client)
   |                     |
   +-- UserPromptSubmit hook --> notification_hook.py (push mode, cursor-tracked)
   |
-  +-- srclight (optional, code indexing MCP server)
+  +-- srclight (optional, code indexing MCP server -- loaded via MCPToolLoader)
 ```
 
 ## Key Architectural Decisions
 
-### ADR-1: pydantic-ai as agent framework
+### ADR-1: Native /api/chat loop over pydantic-ai
 
-> In the context of needing an agent framework for Ollama, facing choices between
-> raw API calls, LangChain, and pydantic-ai, we chose pydantic-ai to get native
-> Ollama support, typed tool definitions, and built-in MCP client capabilities,
-> accepting coupling to the pydantic-ai API surface.
+> *Supersedes the original ADR-1 ("pydantic-ai as agent framework") as of #25.*
+>
+> In the context of running multi-turn tool-using conversations against Ollama,
+> facing a choice between keeping pydantic-ai or owning the loop directly, we
+> replaced pydantic-ai with a hand-rolled multi-turn loop (`run_agent` in
+> `agent.py`) driving `OllamaClient.chat_turn` (ollama.py). Two bugs motivated
+> the switch: (1) pydantic-ai's `ModelMessage` types did not round-trip cleanly
+> to Ollama's /api/chat wire shape, requiring fragile translation on every turn;
+> (2) the OpenAI-compat shim at /v1 (which pydantic-ai used) strips
+> Ollama-specific options like `num_ctx`, making it impossible to raise the
+> default 4096 context window. We accept owning the multi-turn loop, tool
+> dispatch, and streaming accumulation ourselves, with no framework-provided
+> retry or backoff.
 
-### ADR-2: Native message history over text concatenation
+### ADR-2: Ollama-native message history
 
-> In the context of multi-turn sessions, facing a choice between manually
-> concatenating prior messages as text or using pydantic-ai's `message_history`
-> parameter, we chose native message history to preserve tool call/result structure
-> and let the framework manage context, accepting that session serialization must
-> use `ModelMessagesTypeAdapter`.
+> *Supersedes the original ADR-2 ("Native message history over text
+> concatenation") as of #25.*
+>
+> In the context of persisting multi-turn sessions, facing a choice between a
+> typed message model with a serialization adapter or storing Ollama's wire
+> shape directly, we chose plain `list[dict[str, Any]]` -- the exact shape
+> Ollama's /api/chat expects and returns. Session persistence is
+> `json.dumps`/`json.loads` with no translation layer. Resuming a session
+> appends to the list and re-calls `run_agent`. We accept that there is no
+> typed validation on deserialization; the wire format is the contract.
 
-### ADR-3: MCP client for external tool access
+### ADR-3: Unified Tool dataclass for built-in and MCP tools
 
-> In the context of giving subagents access to srclight and recursive sub-agents,
-> facing a choice between custom HTTP integrations or pydantic-ai's MCP client,
-> we chose `MCPServerStdio` toolsets to reuse the MCP protocol and enable the agent
-> to call any MCP server, accepting subprocess management overhead.
+> *Supersedes the original ADR-3 ("MCP client for external tool access") as
+> of #25.*
+>
+> In the context of giving the agent loop a uniform tool interface, facing a
+> choice between separate dispatch paths for Python tools and MCP tools, we
+> chose a single `Tool` dataclass (`agent.py`) with `name`, `description`,
+> `parameters` (JSON Schema), and `fn` (async callable). Built-in Python
+> tools construct `Tool` directly; external MCP servers are spawned once at
+> startup by `MCPToolLoader` (`mcp_loader.py`), which wraps each remote tool
+> as a `Tool` with a thin shim that forwards to the long-lived
+> `ClientSession`. The agent loop dispatches all tools through the same
+> callable interface and never knows the difference. We accept that external
+> MCP child processes are held open for the server's entire lifetime rather
+> than started per-run.
 
 ### ADR-4: Log-based streaming over MCP progress notifications
 
@@ -154,10 +183,13 @@ Claude Code (MCP client)
 
 | Component | Responsibility |
 |-----------|---------------|
-| `server.py` | FastMCP server, tool registration, agent orchestration; per-session worker tasks; backpressure (run semaphore + mailbox cap); `stop_session` |
+| `server.py` | FastMCP server, tool registration, `_run_skill_streaming` orchestration; per-session worker tasks; backpressure (run semaphore + mailbox cap); `stop_session` |
+| `agent.py` | Multi-turn agent loop (`run_agent`), `Tool` dataclass (unified built-in + MCP dispatch), `AgentResult` |
+| `ollama.py` | Native Ollama /api/chat client (`OllamaClient`), NDJSON streaming (`chat_stream`), `ChatClient` Protocol, `TurnResult`, `StreamChunk` |
+| `mcp_loader.py` | External MCP server lifecycle (`MCPToolLoader`): spawns child processes at startup via `AsyncExitStack`, wraps remote tools as `Tool` shims |
 | `config.py` | Configuration from file + environment |
 | `skills.py` | Skill discovery from filesystem |
-| `session.py` | Session persistence with native pydantic-ai messages; per-session `.log` files for streaming output; per-session mailboxes, worker registry, server-wide run semaphore, and `stop_session` drain |
+| `session.py` | Session persistence with Ollama-native messages (`list[dict]`); per-session `.log` files for streaming output; per-session mailboxes, worker registry, server-wide run semaphore, and `stop_session` drain |
 | `inbox.py` | Durable on-disk outbox of completion notifications (uuid7-named JSON files, atomic per-record writes, cursor-based forward drain) |
 | `tools.py` | Built-in tools for file I/O, search, shell |
 | `scripts/notification_hook.py` | Standalone Claude Code `UserPromptSubmit` hook bridge that drains the inbox into prompt context (does not import the package) |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -14,20 +14,25 @@ serves as the tool description.
 ## Session Management
 
 Sessions are UUID-keyed JSON files stored in the configured `session_dir`.
-Each session stores the pydantic-ai native message format (serialized via
-`ModelMessagesTypeAdapter`) to preserve tool call/result structure across turns.
+Each session stores messages in Ollama's /api/chat wire shape --
+`list[dict[str, Any]]` with roles `system`, `user`, `assistant`, and `tool`.
+Persistence is plain `json.dumps`/`json.loads` with no translation layer.
 
-Resuming a session passes the stored messages as `message_history` to
-`Agent.run()`, allowing the model to see the full conversation including
-tool interactions.
+Resuming a session passes the stored message list into `run_agent`, which
+appends the new user message and continues the multi-turn loop. Tool
+call/result structure is preserved natively because the wire shape already
+carries `tool_calls` on assistant turns and `tool_name` on tool turns.
 
 ## Streaming
 
-Skill execution uses `agent.run_stream()` when `config.streaming` is true (the
-default). Text deltas from the model are appended to `{session_dir}/{session_id}.log`
-and flushed after each chunk, while the final complete response is returned
-from the MCP tool as before — the MCP protocol requires tool results to be
-complete, so streaming is a side-channel, not a change to the tool return
+Skill execution uses `run_agent` with an `on_content_delta` callback when
+`config.streaming` is true (the default). Internally, `OllamaClient.chat_stream`
+yields NDJSON `StreamChunk`s from /api/chat; `chat_turn` accumulates them into a
+`TurnResult` and pushes each text delta through the callback. The callback in
+`_run_skill_streaming` (server.py) appends each chunk to
+`{session_dir}/{session_id}.log` and flushes, while the final complete response
+is returned from the MCP tool as before -- the MCP protocol requires tool results
+to be complete, so streaming is a side-channel, not a change to the tool return
 contract.
 
 Each turn of a multi-turn session appends a new `--- prompt ---` /
@@ -118,9 +123,12 @@ The tool returns `{session_id, status, in_flight_cancelled, queued_dropped}`. St
 
 ## Recursive Sub-Agents
 
-Agents can spawn sub-agents by calling this same MCP server through
-pydantic-ai's `MCPServerStdio` toolset. Recursion depth is bounded by
-configuration (`max_recursion_depth`) to prevent infinite loops.
+Agents can spawn sub-agents by calling this same MCP server through the
+external MCP server injection path: the server declares itself in
+`.subagent-mcp.servers.json`, `MCPToolLoader` spawns it as a long-lived
+child, and its tools appear as `Tool` shims alongside the built-in tools.
+Recursion depth is bounded by configuration (`max_recursion_depth`) to
+prevent infinite loops.
 
 ## Security Considerations
 

--- a/src/pydantic_ai_subagent_mcp/__init__.py
+++ b/src/pydantic_ai_subagent_mcp/__init__.py
@@ -1,3 +1,3 @@
-"""MCP server that proxies Claude Code skills to local Ollama models via a native /api/chat agent loop."""
+"""MCP server proxying Claude Code skills to local Ollama models via /api/chat."""
 
 __version__ = "0.1.0"

--- a/src/pydantic_ai_subagent_mcp/__init__.py
+++ b/src/pydantic_ai_subagent_mcp/__init__.py
@@ -1,3 +1,3 @@
-"""MCP server that proxies Claude Code skills to local Ollama models via pydantic-ai agents."""
+"""MCP server that proxies Claude Code skills to local Ollama models via a native /api/chat agent loop."""
 
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- Rewrite ADR-1/2/3 and system context diagram in ARCHITECTURE.md for native /api/chat loop
- Rewrite Session Management, Streaming, and Recursive Sub-Agents in DESIGN.md
- Update README tagline, delegation bullet, MCP config/lifecycle, architecture diagram
- Update CLAUDE.md project structure (add 4 missing files) and drop pydantic-ai from key deps
- Fix `__init__.py` stale docstring

ADR-4/5/6/7 and all concurrency/backpressure/notification/stopping/security sections preserved verbatim.

## Test Plan
- [x] 170 tests pass (`uv run pytest`)
- [x] Quality gate doc-structure check passes
- [x] No stale pydantic-ai references (only historical context in ADR rewrites)
- [x] Component table covers all source files

<details><summary>Design</summary>

**Approach:** Tighten + Trim (B) -- fix all pydantic-ai drift AND simplify prose where the new architecture makes it self-evident. Preserve battle-tested sections verbatim.

**Key decisions:**
- ADRs 1-3 rewritten in place (same numbers, updated content with "Supersedes" note)
- Component table expanded to cover all source files (add agent.py, ollama.py, mcp_loader.py)
- Own branch + PR (not direct to main)
- CLAUDE.md key dependencies updated

Full design: `plans/2026-04-10-doc-update-design.md`

</details>

<details><summary>Implementation Plan</summary>

- Task 1: Create branch (docs/29-post-refactor-rewrite)
- Task 2: Rewrite ARCHITECTURE.md (overview, system context, ADR-1/2/3, component table)
- Task 3: Rewrite DESIGN.md (session management, streaming, recursive sub-agents)
- Task 4: Rewrite README.md (tagline, bullet 3, MCP config/lifecycle, diagram)
- Task 5: Update CLAUDE.md and __init__.py
- Task 6: Verify acceptance criteria

Full plan: `plans/2026-04-10-doc-update-plan.md`

</details>

Closes #29